### PR TITLE
Ensure Unique Type Paths for types with generics. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-/target
+**/target/
+**/*.rs.bk
+
+.DS_Store
+
+.vscode
+.idea
+
 Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,6 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "smallvec",
  "syn 2.0.38",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "smallvec",
  "syn 2.0.38",
  "thiserror",
 ]
@@ -422,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "smallvec",
  "syn 2.0.38",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ scale-info = { version = "2.10.0", features = [
     "docs",
     "serde",
 ] }
-smallvec = "1.11.2"
 syn = { version = "2.0.38", features = ["full", "extra-traits"] }
 thiserror = "1.0.50"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ scale-info = { version = "2.10.0", features = [
     "docs",
     "serde",
 ] }
+smallvec = "1.11.2"
 syn = { version = "2.0.38", features = ["full", "extra-traits"] }
 thiserror = "1.0.50"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod typegen;
+pub mod utils;
 
 pub use typegen::{
     error::TypegenError,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1113,6 +1113,7 @@ fn ensure_unique_type_paths_test() {
             .types
             .iter()
             .map(|t| t.ty.path.segments.clone().join("::"))
+            .filter(|e| !e.is_empty())
             .collect::<Vec<String>>();
         lines.sort();
         lines
@@ -1122,10 +1123,6 @@ fn ensure_unique_type_paths_test() {
     assert_eq!(
         e1,
         vec![
-            "",
-            "",
-            "",
-            "",
             "scale_typegen::tests::Header",
             "scale_typegen::tests::Header",
             "scale_typegen::tests::Header",
@@ -1138,14 +1135,9 @@ fn ensure_unique_type_paths_test() {
     assert_eq!(
         e2,
         vec![
-            "",
-            "",
-            "",
-            "",
-            "scale_typegen::tests::Header",
+            "scale_typegen::tests::Header1",
             "scale_typegen::tests::Header2",
             "scale_typegen::tests::Header3",
         ]
     );
-    // dbg!(registry);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ use syn::parse_quote;
 use crate::{
     tests::utils::{subxt_settings, Testgen},
     typegen::settings::TypeGeneratorSettings,
+    utils::ensure_unique_type_paths,
     DerivesRegistry, TypeSubstitutes,
 };
 
@@ -1087,4 +1088,64 @@ fn opt_out_from_default_substitutes() {
     };
 
     assert_eq!(code.to_string(), expected_code.to_string());
+}
+
+#[test]
+fn ensure_unique_type_paths_test() {
+    use scale_info::PortableRegistry;
+
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    #[scale_info(skip_type_params(Hash))]
+    struct Header<Hash, AccountId> {
+        id: AccountId,
+        hash: Hash,
+    }
+
+    let mut registry = Testgen::new()
+        .with::<Header<String, u32>>()
+        .with::<Header<u8, u32>>()
+        .with::<Header<u16, u32>>()
+        .into_portable_registry();
+
+    let sorted_type_paths = |registry: &PortableRegistry| -> Vec<String> {
+        let mut lines = registry
+            .types
+            .iter()
+            .map(|t| t.ty.path.segments.clone().join("::"))
+            .collect::<Vec<String>>();
+        lines.sort();
+        lines
+    };
+
+    let e1 = sorted_type_paths(&registry);
+    assert_eq!(
+        e1,
+        vec![
+            "",
+            "",
+            "",
+            "",
+            "scale_typegen::tests::Header",
+            "scale_typegen::tests::Header",
+            "scale_typegen::tests::Header",
+        ]
+    );
+
+    ensure_unique_type_paths(&mut registry);
+
+    let e2 = sorted_type_paths(&registry);
+    assert_eq!(
+        e2,
+        vec![
+            "",
+            "",
+            "",
+            "",
+            "scale_typegen::tests::Header",
+            "scale_typegen::tests::Header2",
+            "scale_typegen::tests::Header3",
+        ]
+    );
+    // dbg!(registry);
 }

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -28,6 +28,10 @@ impl Testgen {
         self
     }
 
+    pub fn into_portable_registry(self) -> PortableRegistry {
+        self.registry.into()
+    }
+
     pub fn gen(self, settings: TypeGeneratorSettings) -> TokenStream {
         let registry: PortableRegistry = self.registry.into();
         let type_gen = TypeGenerator::new(&registry, settings).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,78 @@
+use scale_info::{form::PortableForm, Field, PortableRegistry, Type, TypeDef, TypeParameter};
+use smallvec::{smallvec, SmallVec};
 use std::collections::HashMap;
 
-use scale_info::{form::PortableForm, Field, PortableRegistry, Type, TypeDef, TypeParameter};
+pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
+    let mut types_with_same_type_path = HashMap::<&[String], SmallVec<[u32; 2]>>::new();
 
-/// Checks if the two types are equal, but with a bit of a relaxed condition:
-/// If there is any type id involved that is not equal:
-///     If it is from the same generic parameter for a and b:
-///         types still considered equal.
+    // Figure out which types have the same type paths by storing them in the HashMap
+    for ty in types.types.iter() {
+        // Ignore types without a path (i.e prelude types).
+        if ty.ty.path.namespace().is_empty() {
+            continue;
+        };
+        types_with_same_type_path
+            .entry(&ty.ty.path.segments)
+            .or_default()
+            .push(ty.id);
+    }
+
+    let clashing_type_ids = types_with_same_type_path
+        .into_iter()
+        .filter_map(|(_, v)| (v.len() > 1).then_some(v));
+
+    // submit to this buffer type ids (u32), where a number (usize) should be added to the type path to distinguish them.
+    let mut renaming_commands: Vec<(u32, usize)> = vec![];
+
+    for type_ids in clashing_type_ids {
+        // Map N types in type_ids to M new type paths, where M <= N.
+        // types with the same structure should map to the same type path after all.
+        let mut types_with_same_structure: Vec<(&Type<PortableForm>, SmallVec<[u32; 2]>)> = vec![];
+        'outer: for id in type_ids {
+            let type_a = types.resolve(id).expect("type is present; qed;");
+            for (type_b, ids) in types_with_same_structure.iter_mut() {
+                if types_equal_extended_to_params(type_a, type_b) {
+                    ids.push(id);
+                    continue 'outer;
+                }
+            }
+            types_with_same_structure.push((&type_a, smallvec![id]));
+        }
+
+        // Now that the types that share a structure are grouped together, we can order commands to rename them.
+        for (n, (_, group)) in types_with_same_structure.iter().enumerate() {
+            for id in group {
+                renaming_commands.push((*id, n + 1));
+            }
+        }
+    }
+
+    // execute the actual renaming. The `get_mut()` with the usize cast is a bit awkward, but there is currently not `resolve_mut()` function on the `PortableRegistry`.
+    for (id, appendix) in renaming_commands {
+        let ty = types
+            .types
+            .get_mut(id as usize)
+            .expect("type is present; qed;");
+        assert_eq!(ty.id, id);
+        let name = ty.ty.path.segments.last_mut().expect("This is only empty for builtin types, that are filtered out with namespace().is_empty() above; qed;");
+        *name = format!("{name}{appendix}"); // e.g. Header1, Header2, Header3, ...
+    }
+}
+
+/// This function checks if two types that have the same type path,
+/// should be considered as equal in terms of their structure and
+/// their use of generics.
+/// This is checked, because if they are indeed equal it is fine
+/// to generate a single rust type for the two registered typed.
+/// However if they are not equal, we need to deduplicate the type path.
+/// This means modifying the type path of one or both clashing types.
 ///
-/// Should be transitive.
+/// So what types are considered equal?
+/// Types are equal, if their TypeDef is exactly the same.
+/// Types are also considered equal if the TypeDef has the same shape and
+/// all type ids mentioned in the TypeDef are either:
+/// - equal
+/// - or different, but map essentially to the same generic type parameter
 fn types_equal_extended_to_params(a: &Type<PortableForm>, b: &Type<PortableForm>) -> bool {
     let collect_params = |type_params: &[TypeParameter<PortableForm>]| {
         type_params
@@ -19,7 +84,7 @@ fn types_equal_extended_to_params(a: &Type<PortableForm>, b: &Type<PortableForm>
     let type_params_a = collect_params(&a.type_params);
     let type_params_b = collect_params(&a.type_params);
 
-    // returns true if the ids are the same or if they point to the same generic parameter.
+    // returns true if the ids are the same OR if they point to the same generic parameter.
     let ids_equal = |a: u32, b: u32| -> bool {
         a == b
             || matches!((type_params_a.get(&a), type_params_b.get(&b)), (Some(a_name), Some(b_name)) if a_name == b_name)
@@ -61,42 +126,5 @@ fn types_equal_extended_to_params(a: &Type<PortableForm>, b: &Type<PortableForm>
                 && ids_equal(a.bit_store_type.id, b.bit_store_type.id)
         }
         _ => false,
-    }
-}
-
-pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
-    // Filled with clones of types in type registry, for fast lookup. Drawback: Clone :(
-    let mut type_path_lookup = HashMap::<Vec<String>, Type<PortableForm>>::new();
-
-    for ty in &mut types.types {
-        // Ignore types without a path (i.e prelude types).
-        if ty.ty.path.namespace().is_empty() {
-            continue;
-        };
-
-        let mut try_counter = 0;
-        let name_unincremented = ty.ty.path.segments.last().unwrap().clone();
-        loop {
-            let Some(entry) = type_path_lookup.get(&ty.ty.path.segments) else {
-                // Note: clone here not too great, but unavoidable.
-                type_path_lookup.insert(ty.ty.path.segments.clone(), ty.ty.clone());
-                break;
-            };
-            if types_equal_extended_to_params(entry, &ty.ty) {
-                // type is basically a 1:1 copy of the type already present.
-                break;
-            }
-
-            try_counter += 1;
-
-            let name = ty
-                .ty
-                .path
-                .segments
-                .last_mut()
-                .expect("Types have names; qed;");
-
-            *name = format!("{name_unincremented}{}", try_counter + 1);
-        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+
+use scale_info::{form::PortableForm, Field, PortableRegistry, Type, TypeDef, TypeParameter};
+
+/// Checks if the two types are equal, but with a bit of a relaxed condition:
+/// If there is any type id involved that is not equal:
+///     If it is from the same generic parameter for a and b:
+///         types still considered equal.
+///
+/// Should be transitive.
+fn types_equal_extended_to_params(a: &Type<PortableForm>, b: &Type<PortableForm>) -> bool {
+    let collect_params = |type_params: &[TypeParameter<PortableForm>]| {
+        type_params
+            .iter()
+            .filter_map(|p| p.ty.map(|ty| (ty.id, p.name.clone())))
+            .collect::<HashMap<u32, String>>()
+    };
+
+    let type_params_a = collect_params(&a.type_params);
+    let type_params_b = collect_params(&a.type_params);
+
+    // returns true if the ids are the same or if they point to the same generic parameter.
+    let ids_equal = |a: u32, b: u32| -> bool {
+        a == b
+            || matches!((type_params_a.get(&a), type_params_b.get(&b)), (Some(a_name), Some(b_name)) if a_name == b_name)
+    };
+
+    let fields_equal = |a: &[Field<PortableForm>], b: &[Field<PortableForm>]| -> bool {
+        if a.len() != b.len() {
+            return false;
+        }
+        a.iter().zip(b.iter()).all(|(a, b)| {
+            a.name == b.name && a.type_name == b.type_name && ids_equal(a.ty.id, b.ty.id)
+        })
+    };
+
+    match (&a.type_def, &b.type_def) {
+        (TypeDef::Composite(a), TypeDef::Composite(b)) => fields_equal(&a.fields, &b.fields),
+        (TypeDef::Variant(a), TypeDef::Variant(b)) => {
+            a.variants.len() == b.variants.len()
+                && a.variants
+                    .iter()
+                    .zip(b.variants.iter())
+                    .all(|(a, b)| a.name == b.name && fields_equal(&a.fields, &b.fields))
+        }
+        (TypeDef::Sequence(a), TypeDef::Sequence(b)) => ids_equal(a.type_param.id, b.type_param.id),
+        (TypeDef::Array(a), TypeDef::Array(b)) => {
+            a.len == b.len && ids_equal(a.type_param.id, b.type_param.id)
+        }
+        (TypeDef::Tuple(a), TypeDef::Tuple(b)) => {
+            a.fields.len() == b.fields.len()
+                && a.fields
+                    .iter()
+                    .zip(b.fields.iter())
+                    .all(|(a, b)| ids_equal(a.id, b.id))
+        }
+        (TypeDef::Primitive(a), TypeDef::Primitive(b)) => a == b,
+        (TypeDef::Compact(a), TypeDef::Compact(b)) => ids_equal(a.type_param.id, b.type_param.id),
+        (TypeDef::BitSequence(a), scale_info::TypeDef::BitSequence(b)) => {
+            ids_equal(a.bit_order_type.id, b.bit_order_type.id)
+                && ids_equal(a.bit_store_type.id, b.bit_store_type.id)
+        }
+        _ => false,
+    }
+}
+
+pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
+    // Filled with clones of types in type registry, for fast lookup. Drawback: Clone :(
+    let mut type_path_lookup = HashMap::<Vec<String>, Type<PortableForm>>::new();
+
+    for ty in &mut types.types {
+        // Ignore types without a path (i.e prelude types).
+        if ty.ty.path.namespace().is_empty() {
+            continue;
+        };
+
+        let mut try_counter = 0;
+        let name_unincremented = ty.ty.path.segments.last().unwrap().clone();
+        loop {
+            let Some(entry) = type_path_lookup.get(&ty.ty.path.segments) else {
+                // Note: clone here not too great, but unavoidable.
+                type_path_lookup.insert(ty.ty.path.segments.clone(), ty.ty.clone());
+                break;
+            };
+            if types_equal_extended_to_params(entry, &ty.ty) {
+                // type is basically a 1:1 copy of the type already present.
+                break;
+            }
+
+            try_counter += 1;
+
+            let name = ty
+                .ty
+                .path
+                .segments
+                .last_mut()
+                .expect("Types have names; qed;");
+
+            *name = format!("{name_unincremented}{}", try_counter + 1);
+        }
+    }
+}


### PR DESCRIPTION
This PR exposes an `ensure_unique_type_paths` function, like we already use in subxt (in a simpler form). This is intended to be used from subxt, once scale-typegen is a dependency of subxt, to solve [Issue 1247](https://github.com/paritytech/subxt/issues/1247). Please see the last comment of @jsdw on that Issue.

### Testing

Added a test to make sure type paths get amended with numbers. E.g. "Header", "Header2", "Header3", ...
