### PR TITLE
CI/CD to protect master Branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,47 @@
+name: Rust
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+          target: wasm32-unknown-unknown
+
+      - name: fmt
+        run: |
+          cargo fmt --version
+          cargo fmt --all -- --check
+
+      - name: clippy
+        run: |
+          cargo clippy --version
+          cargo clippy --all-targets -- -D warnings
+
+      - name: check
+        run: |
+          cargo check
+
+      - name: build
+        run: |
+          cargo --version --verbose
+          cargo build --all
+          cargo build --all --no-default-features
+
+      - name: test
+        run: |
+          cargo test --all --all-features


### PR DESCRIPTION
Cargo check, fmt, clippy and build commands that run on Github CI/CD.