### PR TITLE
Patch Release 0.1.1: Fix bug regarding substitutes with generic parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# [0.1.0] - 2023-12-08
+
+This is the first release of `scale-typegen` and `scale-typegen-description`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [0.1.1] - 2024-01-05
+
+### Fixed
+
+- A bug regarding type substitutes with generic parameters.
+
 # [0.1.0] - 2023-12-08
 
 This is the first release of `scale-typegen` and `scale-typegen-description`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
@@ -16,7 +16,7 @@ homepage = "https://www.parity.io/"
 [workspace.dependencies]
 
 scale-typegen-description = { version = "0.1.0", path = "description" }
-scale-typegen = { version = "0.1.0", path = "typegen" }
+scale-typegen = { version = "0.1.1", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.0.1"
+version = "0.1.0"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
@@ -15,8 +15,8 @@ homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
 
-scale-typegen-description = { version = "0.0.1", path = "description" }
-scale-typegen = { version = "0.0.1", path = "typegen" }
+scale-typegen-description = { version = "0.1.0", path = "description" }
+scale-typegen = { version = "0.1.0", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }

--- a/description/Cargo.toml
+++ b/description/Cargo.toml
@@ -2,11 +2,10 @@
 name = "scale-typegen-description"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-
-# define the default features:
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/paritytech/scale-typegen"
+description = "Type Description and Examples for SCALE encoded Rust Types"
 
 [features]
 default = ["type-example"]

--- a/description/Cargo.toml
+++ b/description/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-typegen-description"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/description/README.md
+++ b/description/README.md
@@ -1,0 +1,3 @@
+# scale-typegen-description
+
+A library for generating type descriptions and examples for types from a [scale-info](https://github.com/paritytech/scale-info) type registry.

--- a/description/src/lib.rs
+++ b/description/src/lib.rs
@@ -20,7 +20,7 @@
 
 mod description;
 mod formatting;
-mod transformer;
+pub mod transformer;
 
 #[cfg(feature = "type-example")]
 pub use scale_typegen;

--- a/description/src/transformer.rs
+++ b/description/src/transformer.rs
@@ -1,3 +1,4 @@
+//! Providing an abstraction for transforming type registries.
 use std::{cell::RefCell, collections::HashMap};
 
 use scale_info::{form::PortableForm, PortableRegistry, Type};

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-typegen"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-typegen"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 license = "Apache-2.0"

--- a/typegen/README.md
+++ b/typegen/README.md
@@ -1,0 +1,9 @@
+# scale-typegen
+
+A library based on [scale-info](https://github.com/paritytech/scale-info) to transpile portable registries of types into rust type definitions.
+This library exposes a `TypeGenerator` struct which wants to be given two things:
+
+- a `scale_info::PortableRegistry` containing the type information for the types that will be transpiled.
+- a `TypeGeneratorSettings` defining how the code generation happens: What derives and attributes that are applied, substitutes for types, if docs should be generated as well, (..).
+
+It exposes a `generate_types_mod()` function that creates an intermediate representation of a module (`ModuleIR`) that contains types and other modules. It can be directly converted to rust code via `to_token_stream()`.

--- a/typegen/src/typegen/mod.rs
+++ b/typegen/src/typegen/mod.rs
@@ -78,7 +78,7 @@ impl<'a> TypeGenerator<'a> {
             let path = &ty.ty.path;
             // Don't generate a type if it was substituted - the target type might
             // not be in the type registry + our resolution already performs the substitution.
-            if self.settings.substitutes.contains(path) {
+            if self.settings.substitutes.contains(&path.segments) {
                 continue;
             }
 
@@ -438,7 +438,11 @@ impl<'a> TypeGenerator<'a> {
         path: &scale_info::Path<PortableForm>,
         params: &[TypePath],
     ) -> TypePathType {
-        if let Some(substitute) = self.settings.substitutes.for_path_with_params(path, params) {
+        if let Some(substitute) = self
+            .settings
+            .substitutes
+            .for_path_with_params(&path.segments, params)
+        {
             substitute
         } else {
             TypePathType::from_type_def_path(

--- a/typegen/src/typegen/settings/substitutes.rs
+++ b/typegen/src/typegen/settings/substitutes.rs
@@ -358,22 +358,6 @@ pub fn path_segments(path: &syn::Path) -> PathSegments {
     path.segments.iter().map(|x| x.ident.to_string()).collect()
 }
 
-/// Converts a `Vec<String>` into a [`syn::Path`]. Returns None if the Vec was empty.
-///
-/// # Panics
-///
-/// Panics if the segments contain strings that are not valid [`syn::path::PathSegment`]s.
-pub fn path_segments_to_syn_path(segments: &PathSegments) -> Option<syn::Path> {
-    if segments.is_empty() {
-        return None;
-    }
-    let segments = segments.iter().map(|e| {
-        syn::parse_str::<PathSegment>(e)
-            .expect("PathSegments should be syn::PathSegment compatible")
-    });
-    Some(parse_quote!(#(#segments)::*))
-}
-
 /// New-type trait for `TryInto<syn::Path>`
 pub trait TryIntoSynPath {
     /// Turns the type into a [`syn::Path`]. Returns None for empty paths.

--- a/typegen/src/typegen/settings/substitutes.rs
+++ b/typegen/src/typegen/settings/substitutes.rs
@@ -18,8 +18,14 @@ fn error(span: Span, kind: TypeSubstitutionErrorKind) -> TypeSubstitutionError {
 /// to figure out when to swap said type with some provided substitute.
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutes {
-    substitutes: HashMap<syn::Path, Substitute>,
+    substitutes: HashMap<PathSegments, Substitute>,
 }
+
+/// We use this `Vec<String>` as a common denominator, since we need a consistent key for both
+/// `syn::TypePath` and `scale_info::ty::path::Path` types.
+///
+/// Can be obtained from a [`syn::Path`] via the [`path_segments`] function.
+pub type PathSegments = Vec<String>;
 
 /// A type that substitutes another type.
 #[derive(Debug, Clone)]
@@ -97,8 +103,9 @@ impl TypeSubstitutes {
     fn parse_path_substitution(
         src_path: syn::Path,
         target_path: syn::Path,
-    ) -> Result<(syn::Path, Substitute), TypeSubstitutionError> {
+    ) -> Result<(PathSegments, Substitute), TypeSubstitutionError> {
         let param_mapping = Self::parse_path_param_mapping(&src_path, &target_path)?;
+        let src_path = path_segments(&src_path);
         Ok((
             src_path,
             Substitute {
@@ -192,18 +199,15 @@ impl TypeSubstitutes {
     }
 
     /// Given a source type path, return whether a substitute exists for it.
-    pub fn contains(&self, path: impl TryIntoSynPath) -> bool {
-        let Some(syn_path) = path.syn_path() else {
-            return false;
-        };
-        self.substitutes.contains_key(&syn_path)
+    pub fn contains(&self, path: &PathSegments) -> bool {
+        !path.is_empty() && self.substitutes.contains_key(path)
     }
 
     /// Given a source type path and the resolved, supplied type parameters,
     /// return a new path and optionally overwritten type parameters.
     pub fn for_path_with_params(
         &self,
-        path: impl TryIntoSynPath,
+        path: &PathSegments,
         params: &[TypePath],
     ) -> Option<TypePathType> {
         // If we find a substitute type, we'll take the substitute path, and
@@ -241,14 +245,13 @@ impl TypeSubstitutes {
             }
         }
 
-        let path = path.syn_path()?;
         self.substitutes
-            .get(&path)
+            .get(path)
             .map(|sub| replace_params(sub.path.clone(), params, &sub.param_mapping))
     }
 
     /// Returns an iterator over all substitutes.
-    pub fn iter(&self) -> impl Iterator<Item = (&syn::Path, &Substitute)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&PathSegments, &Substitute)> {
         self.substitutes.iter()
     }
 }
@@ -348,6 +351,27 @@ fn is_absolute(path: &syn::Path) -> bool {
 /// tries to convert a [`syn::Path`] into an `AbsolutePath`. Only succeeds if the path is not a relative path.
 pub fn absolute_path(path: syn::Path) -> Result<AbsolutePath, TypeSubstitutionError> {
     path.try_into()
+}
+
+/// Converts a [`syn::Path`] into a `Vec<String>` that contains all the [`syn::Ident`]s of the path as strings.
+pub fn path_segments(path: &syn::Path) -> PathSegments {
+    path.segments.iter().map(|x| x.ident.to_string()).collect()
+}
+
+/// Converts a `Vec<String>` into a [`syn::Path`]. Returns None if the Vec was empty.
+///
+/// # Panics
+///
+/// Panics if the segments contain strings that are not valid [`syn::path::PathSegment`]s.
+pub fn path_segments_to_syn_path(segments: &PathSegments) -> Option<syn::Path> {
+    if segments.is_empty() {
+        return None;
+    }
+    let segments = segments.iter().map(|e| {
+        syn::parse_str::<PathSegment>(e)
+            .expect("PathSegments should be syn::PathSegment compatible")
+    });
+    Some(parse_quote!(#(#segments)::*))
 }
 
 /// New-type trait for `TryInto<syn::Path>`


### PR DESCRIPTION
This was originally the 0.1.0 release PR of scale-typegen, but I repurpose it to issue a patch release to quickly fix a bug that I only discovered when working on [this PR in subxt](https://github.com/paritytech/subxt/pull/1260). 
In Subxt before, we had this mechnanism of storing only the path segments of a path that should be substituted, instead of the entire `syn::Path`. I naively got rid of it when redoing similar logic in this crate. Turns out that was not good and we actually need to break down the `syn::Path` into segments before storing it, to detect all cases where some path should be replaced. 

The implementation I have now, also reduces the number of allocations, because we don't need to clone strings all the time anymore.