### PR TITLE
Add more tests about generics and deduplication

### DIFF
--- a/typegen/src/tests/utils.rs
+++ b/typegen/src/tests/utils.rs
@@ -6,6 +6,7 @@ use scale_info::{PortableRegistry, TypeInfo};
 use syn::parse_quote;
 
 use crate::typegen::ir::module_ir::ModuleIR;
+use crate::utils::ensure_unique_type_paths;
 use crate::{
     typegen::settings::substitutes::absolute_path, DerivesRegistry, TypeGenerator,
     TypeGeneratorSettings, TypeSubstitutes,
@@ -33,7 +34,8 @@ impl Testgen {
     }
 
     pub fn gen(self, settings: TypeGeneratorSettings) -> TokenStream {
-        let registry: PortableRegistry = self.registry.into();
+        let mut registry: PortableRegistry = self.registry.into();
+        ensure_unique_type_paths(&mut registry);
         let type_gen = TypeGenerator::new(&registry, &settings);
         let module = type_gen.generate_types_mod().unwrap();
         module.to_token_stream()


### PR DESCRIPTION
There were some good tests about generics in the subxt/testing/integration-tests/full_client/codegen folder, see https://github.com/paritytech/subxt/pull/1418, that I have ported to scale-typegen, because they are not really subxt-specific.

Question: should we introduce a `deduplicate: bool = true (by default)` setting to the TypegenSetting to apply utils::ensure_unique_type_paths automatically? It is easy to forget using it. But this would force us to clone the registry or use a `&'a mut PortableRegistry` is the `TypeGenerator` which would be weird...