### PR TITLE
Avoid silent failure for associated types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "quote",
  "scale-bits",
  "scale-info",
+ "smallvec",
  "syn 2.0.52",
  "thiserror",
 ]

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -14,6 +14,7 @@ quote = { workspace = true }
 scale-info = { workspace = true }
 syn = { workspace = true }
 thiserror = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 scale-bits = { workspace = true }

--- a/typegen/src/typegen/error.rs
+++ b/typegen/src/typegen/error.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use proc_macro2::Span;
 use quote::ToTokens;
+use scale_info::form::PortableForm;
 
 /// Error for when something went wrong during type generation.
 #[derive(Debug, thiserror::Error)]
@@ -31,6 +32,10 @@ pub enum TypegenError {
     /// The settings do not fit the given type registry.
     #[error("Settings do not fit the given type registry: {0}")]
     SettingsValidation(SettingsValidationError),
+    /// There are two types with the the same type path but a different structure.
+    /// Use [`crate::utils::ensure_unique_type_paths`] on your [`scale_info::PortableRegistry`] to deduplicate type paths.
+    #[error("There are two types with the the same type path {0} but different structure. Use `scale_typegen::utils::ensure_unique_type_paths` on your `PortableRegistry` before, to avoid this error.")]
+    DuplicateTypePath(String),
 }
 
 /// Error attempting to do type substitution.

--- a/typegen/src/typegen/error.rs
+++ b/typegen/src/typegen/error.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 
 use proc_macro2::Span;
 use quote::ToTokens;
-use scale_info::form::PortableForm;
 
 /// Error for when something went wrong during type generation.
 #[derive(Debug, thiserror::Error)]

--- a/typegen/src/typegen/ir/module_ir.rs
+++ b/typegen/src/typegen/ir/module_ir.rs
@@ -9,23 +9,24 @@ use scale_info::form::PortableForm;
 
 /// Represents a Rust `mod`, containing generated types and child `mod`s.
 #[derive(Debug, Clone)]
-pub struct ModuleIR {
+pub struct ModuleIR<'a> {
     /// Name of this module.
     pub name: Ident,
     /// Root module identifier.
     pub root_mod: Ident,
     /// Submodules of this module.
-    pub children: BTreeMap<Ident, ModuleIR>,
+    pub children: BTreeMap<Ident, ModuleIR<'a>>,
     /// Types in this module.
-    pub types: BTreeMap<scale_info::Path<PortableForm>, TypeIR>,
+    pub types:
+        BTreeMap<scale_info::Path<PortableForm>, (&'a scale_info::Type<PortableForm>, TypeIR)>,
 }
 
-impl ToTokens for ModuleIR {
+impl<'a> ToTokens for ModuleIR<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = &self.name;
         let root_mod = &self.root_mod;
         let modules = self.children.values();
-        let types = self.types.values().clone();
+        let types = self.types.values().map(|e| &e.1).clone();
 
         tokens.extend(quote! {
             pub mod #name {
@@ -38,7 +39,7 @@ impl ToTokens for ModuleIR {
     }
 }
 
-impl ModuleIR {
+impl<'a> ModuleIR<'a> {
     /// Create a new [`Module`], with a reference to the root `mod` for resolving type paths.
     pub(crate) fn new(name: Ident, root_mod: Ident) -> Self {
         Self {
@@ -61,7 +62,7 @@ impl ModuleIR {
 
     /// Returns the generated types.
     pub fn types(&self) -> impl Iterator<Item = (&scale_info::Path<PortableForm>, &TypeIR)> {
-        self.types.iter()
+        self.types.iter().map(|(k, v)| (k, &v.1))
     }
 
     /// Returns the root `mod` used for resolving type paths.
@@ -71,7 +72,7 @@ impl ModuleIR {
 
     /// Recursively creates submodules for the given namespace and returns a mutable reference to the innermost module created this way.
     /// Returns itself, if the namespace is empty.
-    pub fn get_or_insert_submodule(&mut self, namespace: &[String]) -> &mut ModuleIR {
+    pub fn get_or_insert_submodule(&mut self, namespace: &[String]) -> &mut ModuleIR<'a> {
         if namespace.is_empty() {
             return self;
         }

--- a/typegen/src/typegen/ir/type_ir.rs
+++ b/typegen/src/typegen/ir/type_ir.rs
@@ -1,6 +1,5 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
-use scale_info::{form::PortableForm, Type};
 
 use crate::typegen::{
     settings::derives::Derives, type_params::TypeParameters, type_path::TypePath,

--- a/typegen/src/typegen/ir/type_ir.rs
+++ b/typegen/src/typegen/ir/type_ir.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, ToTokens};
+use scale_info::{form::PortableForm, Type};
 
 use crate::typegen::{
     settings::derives::Derives, type_params::TypeParameters, type_path::TypePath,

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -87,7 +87,7 @@ pub(crate) fn types_equal_extended_to_params(
     b: &Type<PortableForm>,
 ) -> bool {
     // We map each type ID to all type params if could refer to. Type IDs can refer to multiple parameters:
-    // E.g. Foo<A,B> can be parameterized as Foo<u8,u8>, so if 42 is the type id of u8, a filed with id=42 could refer to eiher A or B.
+    // E.g. Foo<A,B> can be parameterized as Foo<u8,u8>, so if 42 is the type id of u8, a field with id=42 could refer to either A or B.
     fn collect_params(
         type_params: &[TypeParameter<PortableForm>],
     ) -> HashMap<u32, SmallVec<[&str; 2]>> {

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -81,7 +81,10 @@ pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
 /// all type ids mentioned in the TypeDef are either:
 /// - equal
 /// - or different, but map essentially to the same generic type parameter
-fn types_equal_extended_to_params(a: &Type<PortableForm>, b: &Type<PortableForm>) -> bool {
+pub(crate) fn types_equal_extended_to_params(
+    a: &Type<PortableForm>,
+    b: &Type<PortableForm>,
+) -> bool {
     let collect_params = |type_params: &[TypeParameter<PortableForm>]| {
         type_params
             .iter()
@@ -90,12 +93,11 @@ fn types_equal_extended_to_params(a: &Type<PortableForm>, b: &Type<PortableForm>
     };
 
     let type_params_a = collect_params(&a.type_params);
-    let type_params_b = collect_params(&a.type_params);
+    let type_params_b = collect_params(&b.type_params);
 
     if type_params_a.len() != type_params_b.len() {
         return false;
     }
-
     // returns true if the ids are the same OR if they point to the same generic parameter.
     let ids_equal = |a: u32, b: u32| -> bool {
         a == b


### PR DESCRIPTION
Fixes #14 

In the issue #14 it was raised that the type generation can currently override types with the same type path. This should only be valid if the generics of the two types match up, such that the types are essentially the same. 

If you opt for deduplicating the type paths in the `PortableRegistry` with `crate::utils::ensure_unique_type_paths` this problem does not occur because then we generate two distinct types.

This PR adds error checks during the type generation when two types with the same path are encountered. Previously we would have just overridden the first type. 

I added a test to verify that the guards save us from the erroneous behavior reported in #14 