### PR TITLE
Prep for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [0.3.0] - 2024-03-19
+
+- When generating rust code with `TypeGenerator::gerate_types_mod` we now validate that no type 
+is overwritten by another type that has an identical type path but a different structure. In case this happens, 
+we return an error and encourage users to use `scale_typegen::utils::ensure_unique_type_paths` on
+the type registry before. Doing so, should let's the type generation succeed.
+
 # [0.2.0] - 2024-03-01
 
 - bumped dependencies of `scale-*` crates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - When generating rust code with `TypeGenerator::gerate_types_mod` we now validate that no type 
 is overwritten by another type that has an identical type path but a different structure. In case this happens, 
 we return an error and encourage users to use `scale_typegen::utils::ensure_unique_type_paths` on
-the type registry before. Doing so, should let's the type generation succeed.
+the type registry before. Doing so, should let the type generation succeed.
 
 # [0.2.0] - 2024-03-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.2.0"
+version = "0.3.0"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
@@ -15,8 +15,8 @@ homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
 
-scale-typegen-description = { version = "0.2.0", path = "description" }
-scale-typegen = { version = "0.2.0", path = "typegen" }
+scale-typegen-description = { version = "0.3.0", path = "description" }
+scale-typegen = { version = "0.3.0", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # scale-typegen
 
-**Currently a work in progress**
-
 A library based on [scale-info](https://github.com/paritytech/scale-info) to transpile portable registries of types into rust type definitions.
 This library exposes a `TypeGenerator` struct which wants to be given two things:
 

--- a/typegen/src/tests/mod.rs
+++ b/typegen/src/tests/mod.rs
@@ -288,6 +288,7 @@ fn can_omit_compact_encoding() {
     }
 
     #[derive(TypeInfo)]
+    #[allow(unused)]
     pub struct Centimeter(Compact<u16>);
 
     #[allow(unused)]


### PR DESCRIPTION
# [0.3.0] - 2024-03-19

- When generating rust code with `TypeGenerator::gerate_types_mod` we now validate that no type 
is overwritten by another type that has an identical type path but a different structure. In case this happens, 
we return an error and encourage users to use `scale_typegen::utils::ensure_unique_type_paths` on
the type registry before. Doing so, should let the type generation succeed.
