### PR TITLE
Fix bug with `ensure_unique_type_paths` and prep for patch release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.3.1] - 2024-03-21
+
+- Fix logic bug in `scale_typegen::utils::ensure_unique_type_paths`.
+
 # [0.3.0] - 2024-03-19
 
 - When generating rust code with `TypeGenerator::gerate_types_mod` we now validate that no type 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# [0.3.1] - 2024-03-21
+# [0.4.0] - 2024-03-21
 
 - Fix logic bug in `scale_typegen::utils::ensure_unique_type_paths`.
+
+- You can now specify a custom path to the `alloc` crate in the settings. It is used for type paths that are typically in the rust prelude or in the `std` library, like `Vec`, `Box` and `String`. This gives you the option to use the generated code in a `no_std` environment.
 
 # [0.3.0] - 2024-03-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.3.0"
+version = "0.3.1"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
@@ -15,8 +15,8 @@ homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
 
-scale-typegen-description = { version = "0.3.0", path = "description" }
-scale-typegen = { version = "0.3.0", path = "typegen" }
+scale-typegen-description = { version = "0.3.1", path = "description" }
+scale-typegen = { version = "0.3.1", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.3.1"
+version = "0.4.0"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
@@ -15,8 +15,8 @@ homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
 
-scale-typegen-description = { version = "0.3.1", path = "description" }
-scale-typegen = { version = "0.3.1", path = "typegen" }
+scale-typegen-description = { version = "0.4.0", path = "description" }
+scale-typegen = { version = "0.4.0", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }


### PR DESCRIPTION
Fixes https://github.com/paritytech/scale-typegen/issues/21

There was a single variable wrong in `ensure_unique_type_paths`  after all...
I tested this version of scale-typegen locally against `subxt`, the codegen there now works again like it should, does not error.

I added a test to make sure that ensuring unique type paths actually works.

**Attention:** This PR does does fix the problems outlined in https://github.com/paritytech/scale-typegen/issues/19
For example running this version of scale-typegen against subxt results in types `BoundedVec1`, `BoundedVec2`,  ... `BoundedVec38` being generated, where a single ` BoundedVec` is totally enough, we are just not smart enough to realize that they should be the same. 