### PR TITLE
Fix type enumeration for stripped metadata in subxt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.4.1] - 2024-03-22
+
+- Fix type id resolving in `scale_typegen::utils::ensure_unique_type_paths` for cases where a type's index and id do not line up.
+
 # [0.4.0] - 2024-03-21
 
 - Fix logic bug in `scale_typegen::utils::ensure_unique_type_paths`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,17 +6,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.4.0"
+version = "0.4.1"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
 homepage = "https://www.parity.io/"
 
-
 [workspace.dependencies]
-
-scale-typegen-description = { version = "0.4.0", path = "description" }
-scale-typegen = { version = "0.4.0", path = "typegen" }
+scale-typegen-description = { version = "0.4.1", path = "description" }
+scale-typegen = { version = "0.4.1", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -13,11 +13,13 @@ pub fn syn_type_path(ty: &Type<PortableForm>) -> Result<syn::TypePath, TypegenEr
 
 /// Deduplicates type paths in the provided Registry.
 pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
-    let mut types_with_same_type_path_grouped_by_shape = HashMap::<&[String], Vec<Vec<u32>>>::new();
+    let mut types_with_same_type_path_grouped_by_shape =
+        HashMap::<&[String], Vec<Vec<usize>>>::new();
 
     // First, group types if they are similar (same path, same shape).
+    for (ty_idx, ty) in types.types.iter().enumerate() {
+        // Note: ty_idx and ty.id might be different
 
-    for (ty_id, ty) in types.types.iter().enumerate() {
         // Ignore types without a path (i.e prelude types).
         if ty.ty.path.namespace().is_empty() {
             continue;
@@ -31,10 +33,10 @@ pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
         // Compare existing groups to check which to add our type ID to.
         let mut added_to_existing_group = false;
         for group in groups_with_same_path.iter_mut() {
-            let ty_id_b = group[0]; // all types in group are same shape; just check any one of them.
-            let ty_b = types.resolve(ty_id_b).expect("ty exists");
-            if types_equal_extended_to_params(&ty.ty, ty_b) {
-                group.push(ty.id);
+            let other_ty_in_group_idx = group[0]; // all types in group are same shape; just check any one of them.
+            let other_ty_in_group = types.types.get(other_ty_in_group_idx).expect("ty exists");
+            if types_equal_extended_to_params(&ty.ty, &other_ty_in_group.ty) {
+                group.push(ty_idx);
                 added_to_existing_group = true;
                 break;
             }
@@ -42,7 +44,7 @@ pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
 
         // We didn't find a matching group, so add it to a new one.
         if !added_to_existing_group {
-            groups_with_same_path.push(vec![ty_id as u32])
+            groups_with_same_path.push(vec![ty_idx])
         }
     }
 


### PR DESCRIPTION
I discovered that when retaining only parts of the metadata in subxt, we can end up with types where their `id` and their `index` in the `Vec` they are held in do not line up. 
This caused the ui-tests to fail on the subxt core PR, [see this action run](https://github.com/paritytech/subxt/actions/runs/8390040301/job/22978026818).

I verified locally that with this change the UI-tests succeed again in subxt.
Though I suspect that there is a deeper problem somewhere and that we actually do not want to have the index and id of types to differ anywhere.

Let's just push this fix.
