### PR TITLE
Use type index for now, and prep 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.4.2] - 2024-03-26
+
+- Revert some code simplification in 0.4.1 so that older metadata (built with scale-info versions prior to 2.11.1 and using the `retain()` method) is more likely to work.
+
 # [0.4.1] - 2024-03-22
 
 - Bump `scale-info` to 2.11.1 to fix an issue in `scale_typegen::utils::ensure_unique_type_paths` for cases where a type's index and id do not line up, and simplify code a touch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.4.1"
+version = "0.4.2"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
 homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
-scale-typegen-description = { version = "0.4.1", path = "description" }
-scale-typegen = { version = "0.4.1", path = "typegen" }
+scale-typegen-description = { version = "0.4.2", path = "description" }
+scale-typegen = { version = "0.4.2", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }


### PR DESCRIPTION
After getting some errors in Subxt, I realised that older metadata produced with versions of scale-info prior to 2.11.1 and using the `retain` method (ie anything that's had pallets/runtime APIs stripped out of it) would produce panics in `scale-typegen`. So, for now, let's revert to using the type index rather than ID to avoid breaking using Subxt etc against older metadata files.

Tested this against subxt with pre-2.11.1 metadatas and it seemed to be ok, whereas without it you run into panics (unless you update artifacts)