### PR TITLE
Prep for 0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.7.0] - 2024-05-15
+
+- Bump `scale-value` to 0.16.0, in order to have only one `scale-decode` in the hierarchy.
+
 # [0.6.0] - 2024-05-15
 
 - Bump `scale-decode` to 0.13.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e10e0d345101a013ca3af62c2d44d20213d543cc64d96080c68d931e54360c5"
+checksum = "b12ebca36cec2a3f983c46295b282b35e5f8496346fb859a8776dad5389e5389"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "indoc",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9e20eb2f3b02cb16f7ccb575c599f4624567c9ad58206d61995e7fc2a0efb7"
+checksum = "f2cf9738c263c665144177201126bdad39d3d62512152f178f35002228026976"
 dependencies = [
  "base58",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.6.0"
+version = "0.7.0"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
 homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
-scale-typegen-description = { version = "0.6.0", path = "description" }
-scale-typegen = { version = "0.6.0", path = "typegen" }
+scale-typegen-description = { version = "0.7.0", path = "description" }
+scale-typegen = { version = "0.7.0", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }
@@ -33,6 +33,6 @@ bitvec = { version = "1", default-features = false, features = ["alloc"] }
 pretty_assertions = "1.4.0"
 anyhow = "1.0.75"
 peekmore = "1.3.0"
-scale-value = "0.15.0"
+scale-value = "0.16.0"
 rand_chacha = "0.3.1"
 rand = "0.8.5"


### PR DESCRIPTION
I screwed up and forgot to update scale-value as well in the 0.6 release, leading to two `scale-decode`'s in the hierarchy. This release fixes that.