### PR TITLE
Recursive type equality check for de-duplicating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,6 @@ dependencies = [
  "quote",
  "scale-bits",
  "scale-info",
- "smallvec",
  "syn 2.0.60",
  "thiserror",
 ]

--- a/typegen/Cargo.toml
+++ b/typegen/Cargo.toml
@@ -14,7 +14,6 @@ quote = { workspace = true }
 scale-info = { workspace = true }
 syn = { workspace = true }
 thiserror = { workspace = true }
-smallvec = { workspace = true }
 
 [dev-dependencies]
 scale-bits = { workspace = true }

--- a/typegen/src/tests/mod.rs
+++ b/typegen/src/tests/mod.rs
@@ -20,19 +20,19 @@ use crate::{
 
 mod utils;
 
-//// Dev note: It would be great to get this test passing, but the current type equality check
-//// picks exactly one matching generic to line up to a type, and not a set of them. The problem with
-//// a set would be that you can have eg three types like this in the registry:
-////
-//// ```txt
-//// 1: struct Foo<T = u8, U = u8, V = u8>(u8, u8, u8);
-//// 2: struct Foo<T = u8, U = u16, V = u32>(u8, u16, u32);
-//// 3: struct Foo<T = u8, U = u16, V = u32>(u32, u16, u8);
-//// ```
-////
-//// 1 == 2 and 1 == 3 (both could be represented by `Foo<T,U,V>(T,U,V)`) but 2 != 3.
-//// needs more thought.
-////
+// // Dev note: It would be great to get this test passing, but the current type equality check
+// // picks exactly one matching generic to line up to a type, and not a set of them. The problem with
+// // a set would be that you can have eg three types like this in the registry:
+// //
+// // ```txt
+// // 1: struct Foo<T = u8, U = u8, V = u8>(u8, u8, u8);
+// // 2: struct Foo<T = u8, U = u16, V = u32>(u8, u16, u32);
+// // 3: struct Foo<T = u8, U = u16, V = u32>(u32, u16, u8);
+// // ```
+// //
+// // 1 == 2 and 1 == 3 (both could be represented by `Foo<T,U,V>(T,U,V)`) but 2 != 3.
+// // needs more thought.
+// //
 // #[test]
 // fn more_than_1_generic_parameters() {
 //     #[allow(unused)]

--- a/typegen/src/tests/mod.rs
+++ b/typegen/src/tests/mod.rs
@@ -20,57 +20,70 @@ use crate::{
 
 mod utils;
 
-#[test]
-fn more_than_1_generic_parameters() {
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct Foo<T, U, V, W> {
-        a: T,
-        b: U,
-        c: V,
-        d: W,
-    }
-
-    #[allow(unused)]
-    #[derive(TypeInfo)]
-    struct Bar {
-        p: Foo<u32, u32, u64, u128>,
-        q: Foo<u8, u8, u8, u8>,
-    }
-
-    let generated = Testgen::new()
-        .with::<Bar>()
-        .gen_tests_mod(Default::default());
-
-    #[rustfmt::skip]
-    let expected = quote!(
-        pub mod tests {
-            use super::types;
-            pub struct Bar {
-                pub p: types::scale_typegen::tests::Foo<
-                    ::core::primitive::u32,
-                    ::core::primitive::u32,
-                    ::core::primitive::u64,
-                    ::core::primitive::u128
-                >,
-                pub q: types::scale_typegen::tests::Foo<
-                    ::core::primitive::u8,
-                    ::core::primitive::u8,
-                    ::core::primitive::u8,
-                    ::core::primitive::u8
-                >,
-            }
-            pub struct Foo<_0, _1, _2, _3> {
-                pub a: _0,
-                pub b: _1,
-                pub c: _2,
-                pub d: _3,
-            }
-        }
-    );
-
-    assert_eq!(generated.to_string(), expected.to_string());
-}
+//// Dev note: It would be great to get this test passing, but the current type equality check
+//// picks exactly one matching generic to line up to a type, and not a set of them. The problem with
+//// a set would be that you can have eg three types like this in the registry:
+////
+//// ```txt
+//// 1: struct Foo<T = u8, U = u8, V = u8>(u8, u8, u8);
+//// 2: struct Foo<T = u8, U = u16, V = u32>(u8, u16, u32);
+//// 3: struct Foo<T = u8, U = u16, V = u32>(u32, u16, u8);
+//// ```
+////
+//// 1 == 2 and 1 == 3 (both could be represented by `Foo<T,U,V>(T,U,V)`) but 2 != 3.
+//// needs more thought.
+////
+// #[test]
+// fn more_than_1_generic_parameters() {
+//     #[allow(unused)]
+//     #[derive(TypeInfo)]
+//     struct Foo<T, U, V, W> {
+//         a: T,
+//         b: U,
+//         c: V,
+//         d: W,
+//     }
+//
+//     #[allow(unused)]
+//     #[derive(TypeInfo)]
+//     struct Bar {
+//         p: Foo<u32, u32, u64, u128>,
+//         q: Foo<u8, u8, u8, u8>,
+//     }
+//
+//     let generated = Testgen::new()
+//         .with::<Bar>()
+//         .gen_tests_mod(Default::default());
+//
+//     #[rustfmt::skip]
+//     let expected = quote!(
+//         pub mod tests {
+//             use super::types;
+//             pub struct Bar {
+//                 pub p: types::scale_typegen::tests::Foo<
+//                     ::core::primitive::u32,
+//                     ::core::primitive::u32,
+//                     ::core::primitive::u64,
+//                     ::core::primitive::u128
+//                 >,
+//                 pub q: types::scale_typegen::tests::Foo<
+//                     ::core::primitive::u8,
+//                     ::core::primitive::u8,
+//                     ::core::primitive::u8,
+//                     ::core::primitive::u8
+//                 >,
+//             }
+//             pub struct Foo<_0, _1, _2, _3> {
+//                 pub a: _0,
+//                 pub b: _1,
+//                 pub c: _2,
+//                 pub d: _3,
+//             }
+//         }
+//     );
+//
+//     assert_eq!(generated.to_string(), expected.to_string());
+// }
 
 #[test]
 fn dupe_types_do_not_overwrite_each_other() {

--- a/typegen/src/tests/utils.rs
+++ b/typegen/src/tests/utils.rs
@@ -178,7 +178,7 @@ pub(super) fn subxt_default_substitutes() -> TypeSubstitutes {
 
 const TESTS_MOD_PATH: &[&str] = &["scale_typegen", "tests"];
 
-fn get_mod<'a>(module: &'a ModuleIR, path_segs: &[&'static str]) -> Option<&'a ModuleIR<'a>> {
+fn get_mod<'a>(module: &'a ModuleIR, path_segs: &[&'static str]) -> Option<&'a ModuleIR> {
     let (mod_name, rest) = path_segs.split_first()?;
     let mod_ident: Ident = syn::parse_str(mod_name).unwrap();
     let module = module.children.get(&mod_ident)?;

--- a/typegen/src/typegen/ir/module_ir.rs
+++ b/typegen/src/typegen/ir/module_ir.rs
@@ -11,19 +11,18 @@ use scale_info::form::PortableForm;
 
 /// Represents a Rust `mod`, containing generated types and child `mod`s.
 #[derive(Debug, Clone)]
-pub struct ModuleIR<'a> {
+pub struct ModuleIR {
     /// Name of this module.
     pub name: Ident,
     /// Root module identifier.
     pub root_mod: Ident,
     /// Submodules of this module.
-    pub children: BTreeMap<Ident, ModuleIR<'a>>,
+    pub children: BTreeMap<Ident, ModuleIR>,
     /// Types in this module.
-    pub types:
-        BTreeMap<scale_info::Path<PortableForm>, (&'a scale_info::Type<PortableForm>, TypeIR)>,
+    pub types: BTreeMap<scale_info::Path<PortableForm>, (u32, TypeIR)>,
 }
 
-impl<'a> ToTokensWithSettings for ModuleIR<'a> {
+impl ToTokensWithSettings for ModuleIR {
     fn to_tokens(&self, tokens: &mut TokenStream, settings: &TypeGeneratorSettings) {
         let name = &self.name;
         let root_mod = &self.root_mod;
@@ -48,7 +47,7 @@ impl<'a> ToTokensWithSettings for ModuleIR<'a> {
     }
 }
 
-impl<'a> ModuleIR<'a> {
+impl ModuleIR {
     /// Create a new [`Module`], with a reference to the root `mod` for resolving type paths.
     pub(crate) fn new(name: Ident, root_mod: Ident) -> Self {
         Self {
@@ -81,7 +80,7 @@ impl<'a> ModuleIR<'a> {
 
     /// Recursively creates submodules for the given namespace and returns a mutable reference to the innermost module created this way.
     /// Returns itself, if the namespace is empty.
-    pub fn get_or_insert_submodule(&mut self, namespace: &[String]) -> &mut ModuleIR<'a> {
+    pub fn get_or_insert_submodule(&mut self, namespace: &[String]) -> &mut ModuleIR {
         if namespace.is_empty() {
             return self;
         }

--- a/typegen/src/typegen/mod.rs
+++ b/typegen/src/typegen/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::btree_map::Entry;
 
-use crate::{utils::types_equal_extended_to_params, TypegenError};
+use crate::{utils::types_equal, TypegenError};
 
 use self::{
     ir::module_ir::ModuleIR,
@@ -91,21 +91,21 @@ impl<'a> TypeGenerator<'a> {
             }
 
             // if the type is not a builtin type, insert it into the respective module
-            let ty = &ty.ty;
-            if let Some(type_ir) = self.create_type_ir(ty, &flat_derives_registry)? {
+            let ty_id = ty.id;
+            if let Some(type_ir) = self.create_type_ir(&ty.ty, &flat_derives_registry)? {
                 // Create the module this type should go into
                 let innermost_module = root_mod.get_or_insert_submodule(namespace);
                 match innermost_module.types.entry(path.clone()) {
                     Entry::Vacant(e) => {
-                        e.insert((ty, type_ir));
+                        e.insert((ty_id, type_ir));
                     }
                     Entry::Occupied(e) => {
                         // There is already a type with the same type path present.
                         // We do not just want to override it, so we check if the two types are semantically similar (structure + generics).
                         // If not, return an error, if yes, just keep the first one.
-                        let other_ty = &e.get().0;
-                        if !types_equal_extended_to_params(ty, other_ty) {
-                            return Err(TypegenError::DuplicateTypePath(ty.path.to_string()));
+                        let other_ty_id = e.get().0;
+                        if !types_equal(ty_id, other_ty_id, self.type_registry) {
+                            return Err(TypegenError::DuplicateTypePath(ty.ty.path.to_string()));
                         }
                     }
                 };

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -73,13 +73,15 @@ pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
     }
 }
 
-/// This attempts to check whether two types are equal.
+/// This attempts to check whether two types are equal in terms of their shape.
+/// In other words: should we de-duplicate these types during codegen.
 ///
-/// It recurses through types, keeping track of any generic parameters we've seen so far
-/// such that it can attempt to map seen type IDs back to generic parameters if they aren't
-/// already equal.
-///
-/// It also checks that the name, param names and shape all lines up between two types.
+/// The basic algorithm here is:
+/// - If type IDs match, they are the same.
+/// - If type IDs can be explained by the same generic parameter, they are the same.
+/// - If type paths or generic names don't match, they are different.
+/// - If the corresponding TypeDefs (shape of type) is different, they are different.
+/// - Else, recurse through any contained type IDs and start from the top.
 pub(crate) fn types_equal(a: u32, b: u32, types: &PortableRegistry) -> bool {
     let mut a_visited = HashSet::new();
     let mut b_visited = HashSet::new();

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -144,7 +144,7 @@ fn types_equal_inner(
     let b_ty = types.resolve(b).expect("type b should exist in registry");
 
     // Paths differ; types won't be equal then!
-    if &a_ty.path.segments != &b_ty.path.segments {
+    if a_ty.path.segments != b_ty.path.segments {
         return false;
     }
 

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -1,6 +1,6 @@
-use scale_info::{form::PortableForm, Field, PortableRegistry, Type, TypeDef, TypeParameter};
-use smallvec::{smallvec, SmallVec};
-use std::collections::{hash_map::Entry, HashMap};
+use self::generics_list::GenericsList;
+use scale_info::{form::PortableForm, Field, PortableRegistry, Type, TypeDef};
+use std::collections::{HashMap, HashSet};
 
 use crate::TypegenError;
 
@@ -38,10 +38,7 @@ pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
         let mut added_to_existing_group = false;
         for group in groups_with_same_path.iter_mut() {
             let other_ty_in_group_idx = group[0]; // all types in group are same shape; just check any one of them.
-            let other_ty_in_group = types
-                .resolve(other_ty_in_group_idx)
-                .expect("type is present (1); qed;");
-            if types_equal_extended_to_params(ty, other_ty_in_group) {
+            if types_equal(ty_idx, other_ty_in_group_idx, types) {
                 group.push(ty_idx);
                 added_to_existing_group = true;
                 break;
@@ -76,110 +73,254 @@ pub fn ensure_unique_type_paths(types: &mut PortableRegistry) {
     }
 }
 
-/// This function checks if two types that have the same type path,
-/// should be considered as equal in terms of their structure and
-/// their use of generics.
-/// This is checked, because if they are indeed equal it is fine
-/// to generate a single rust type for the two registered typed.
-/// However if they are not equal, we need to deduplicate the type path.
-/// This means modifying the type path of one or both clashing types.
+/// This attempts to check whether two types are equal.
 ///
-/// So what types are considered equal?
-/// Types are equal, if their TypeDef is exactly the same.
-/// Types are also considered equal if the TypeDef has the same shape and
-/// all type ids mentioned in the TypeDef are either:
-/// - equal
-/// - or different, but map essentially to the same generic type parameter
-pub(crate) fn types_equal_extended_to_params(
-    a: &Type<PortableForm>,
-    b: &Type<PortableForm>,
+/// It recurses through types, keeping track of any generic parameters we've seen so far
+/// such that it can attempt to map seen type IDs back to generic parameters if they aren'T
+/// already equal.
+///
+/// It also checks that the name, param names and shape all lines up bewteen two types.
+pub(crate) fn types_equal(a: u32, b: u32, types: &PortableRegistry) -> bool {
+    let mut a_visited = HashSet::new();
+    let mut b_visited = HashSet::new();
+    types_equal_inner(
+        a,
+        &GenericsList::empty(),
+        &mut a_visited,
+        b,
+        &GenericsList::empty(),
+        &mut b_visited,
+        types,
+    )
+}
+
+// Panics if the given type ID is not found in the registry.
+fn types_equal_inner(
+    a: u32,
+    a_parent_params: &GenericsList,
+    a_visited: &mut HashSet<u32>,
+    b: u32,
+    b_parent_params: &GenericsList,
+    b_visited: &mut HashSet<u32>,
+    types: &PortableRegistry,
 ) -> bool {
-    // We map each type ID to all type params if could refer to. Type IDs can refer to multiple parameters:
-    // E.g. Foo<A,B> can be parameterized as Foo<u8,u8>, so if 42 is the type id of u8, a field with id=42 could refer to either A or B.
-    fn collect_params(
-        type_params: &[TypeParameter<PortableForm>],
-    ) -> HashMap<u32, SmallVec<[&str; 2]>> {
-        let mut hm: HashMap<u32, SmallVec<[&str; 2]>> = HashMap::new();
-        for p in type_params {
-            if let Some(ty) = &p.ty {
-                match hm.entry(ty.id) {
-                    Entry::Occupied(mut e) => {
-                        e.get_mut().push(p.name.as_str());
-                    }
-                    Entry::Vacant(e) => {
-                        e.insert(smallvec![p.name.as_str()]);
-                    }
-                }
-            }
-        }
-        hm
+    // IDs are the same; types must be identical!
+    if a == b {
+        return true;
     }
 
-    let type_params_a = collect_params(&a.type_params);
-    let type_params_b = collect_params(&b.type_params);
+    // Make note of these IDs in case we recurse and see them again.
+    let seen_a = !a_visited.insert(a);
+    let seen_b = !b_visited.insert(b);
 
-    if a.type_params.len() != b.type_params.len() {
+    // One type is recursive and the other isn't; they are different.
+    // If neither type is recursive, we keep checking.
+    if seen_a != seen_b {
         return false;
     }
-    // Returns true if the ids are the same OR if they point to the same generic parameter.
-    let ids_equal = |a: u32, b: u32| -> bool {
-        if a == b {
+
+    // Both types are recursive, and they look the same based on the above,
+    // so assume all is well, since we've already checked other things in prev recursion.
+    if seen_a && seen_b {
+        return true;
+    }
+
+    // Make note of whether these IDs (might) correspond to any specific generic.
+    let a_generic_idx = a_parent_params.index_for_type_id(a);
+    let b_generic_idx = b_parent_params.index_for_type_id(b);
+
+    // If both IDs map to same generic param, then we'll assume equal. If they don't
+    // then we need to keep checking other properties (eg Vec<bool> and Vec<u8> will have
+    // different type IDs but may be the same type if the bool+u8 line up to generic params).
+    if let (Some(a_idx), Some(b_idx)) = (a_generic_idx, b_generic_idx) {
+        if a_idx == b_idx {
             return true;
         }
-        let Some(a_param_names) = type_params_a.get(&a) else {
-            return false;
-        };
-        let Some(b_param_names) = type_params_b.get(&b) else {
-            return false;
-        };
-        // Check if there is any intersection, meaning that both IDs map to the same generic type param:
-        a_param_names.iter().any(|a_p| b_param_names.contains(a_p))
+    }
+
+    let a_ty = types.resolve(a).expect("type a should exist in registry");
+    let b_ty = types.resolve(b).expect("type b should exist in registry");
+
+    // Paths differ; types won't be equal then!
+    if &a_ty.path.segments != &b_ty.path.segments {
+        return false;
+    }
+
+    // Names of type params don't line up, so different then!
+    if a_ty
+        .type_params
+        .iter()
+        .zip(&b_ty.type_params)
+        .any(|(a, b)| a.name != b.name)
+    {
+        return false;
+    }
+
+    // We'll lazily extend our type params only if the shapes match.
+    let calc_params = || {
+        let a_params = a_parent_params.extend(&a_ty.type_params);
+        let b_params = b_parent_params.extend(&b_ty.type_params);
+        (a_params, b_params)
     };
 
-    let fields_equal = |a: &[Field<PortableForm>], b: &[Field<PortableForm>]| -> bool {
+    // Capture a few variables to avoid some repetition later when we recurse.
+    let mut types_equal_recurse =
+        |a: u32, a_params: &GenericsList, b: u32, b_params: &GenericsList| -> bool {
+            types_equal_inner(a, a_params, a_visited, b, b_params, b_visited, types)
+        };
+
+    // Check that all of the fields of some type are equal.
+    let mut fields_equal = |a: &[Field<PortableForm>],
+                            a_params: &GenericsList,
+                            b: &[Field<PortableForm>],
+                            b_params: &GenericsList|
+     -> bool {
         if a.len() != b.len() {
             return false;
         }
         a.iter().zip(b.iter()).all(|(a, b)| {
-            a.name == b.name && a.type_name == b.type_name && ids_equal(a.ty.id, b.ty.id)
+            a.name == b.name
+                && a.type_name == b.type_name
+                && types_equal_recurse(a.ty.id, a_params, b.ty.id, b_params)
         })
     };
 
-    match (&a.type_def, &b.type_def) {
-        (TypeDef::Composite(a), TypeDef::Composite(b)) => fields_equal(&a.fields, &b.fields),
-        (TypeDef::Variant(a), TypeDef::Variant(b)) => {
-            a.variants.len() == b.variants.len()
-                && a.variants
-                    .iter()
-                    .zip(b.variants.iter())
-                    .all(|(a, b)| a.name == b.name && fields_equal(&a.fields, &b.fields))
+    // Check that the shape of the types and contents are equal.
+    match (&a_ty.type_def, &b_ty.type_def) {
+        (TypeDef::Composite(a), TypeDef::Composite(b)) => {
+            let (a_params, b_params) = calc_params();
+            fields_equal(&a.fields, &a_params, &b.fields, &b_params)
         }
-        (TypeDef::Sequence(a), TypeDef::Sequence(b)) => ids_equal(a.type_param.id, b.type_param.id),
+        (TypeDef::Variant(a), TypeDef::Variant(b)) => {
+            let (a_params, b_params) = calc_params();
+            a.variants.len() == b.variants.len()
+                && a.variants.iter().zip(b.variants.iter()).all(|(a, b)| {
+                    a.name == b.name && fields_equal(&a.fields, &a_params, &b.fields, &b_params)
+                })
+        }
+        (TypeDef::Sequence(a), TypeDef::Sequence(b)) => {
+            let (a_params, b_params) = calc_params();
+            types_equal_recurse(a.type_param.id, &a_params, b.type_param.id, &b_params)
+        }
         (TypeDef::Array(a), TypeDef::Array(b)) => {
-            a.len == b.len && ids_equal(a.type_param.id, b.type_param.id)
+            let (a_params, b_params) = calc_params();
+            a.len == b.len
+                && types_equal_recurse(a.type_param.id, &a_params, b.type_param.id, &b_params)
         }
         (TypeDef::Tuple(a), TypeDef::Tuple(b)) => {
+            let (a_params, b_params) = calc_params();
             a.fields.len() == b.fields.len()
                 && a.fields
                     .iter()
                     .zip(b.fields.iter())
-                    .all(|(a, b)| ids_equal(a.id, b.id))
+                    .all(|(a, b)| types_equal_recurse(a.id, &a_params, b.id, &b_params))
         }
         (TypeDef::Primitive(a), TypeDef::Primitive(b)) => a == b,
-        (TypeDef::Compact(a), TypeDef::Compact(b)) => ids_equal(a.type_param.id, b.type_param.id),
-        (TypeDef::BitSequence(a), scale_info::TypeDef::BitSequence(b)) => {
-            ids_equal(a.bit_order_type.id, b.bit_order_type.id)
-                && ids_equal(a.bit_store_type.id, b.bit_store_type.id)
+        (TypeDef::Compact(a), TypeDef::Compact(b)) => {
+            let (a_params, b_params) = calc_params();
+            types_equal_recurse(a.type_param.id, &a_params, b.type_param.id, &b_params)
         }
+        (TypeDef::BitSequence(a), scale_info::TypeDef::BitSequence(b)) => {
+            let (a_params, b_params) = calc_params();
+            let order_equal = types_equal_recurse(
+                a.bit_order_type.id,
+                &a_params,
+                b.bit_order_type.id,
+                &b_params,
+            );
+            let store_equal = types_equal_recurse(
+                a.bit_store_type.id,
+                &a_params,
+                b.bit_store_type.id,
+                &b_params,
+            );
+            order_equal && store_equal
+        }
+        // Type defs don't match; types aren't the same!
         _ => false,
+    }
+}
+
+/// Just a small helper for the [`types_equal_inner`] function, to track where generic params
+/// are in order to see whether different type IDs may actually be represented by the same generics.
+mod generics_list {
+    use scale_info::{form::PortableForm, TypeParameter};
+    use std::rc::Rc;
+
+    /// A list of generics by type ID. For a given type ID, we'll either
+    /// return the index of the first generic param we find that matches it,
+    /// or None. We can extend this list with more generics as we go.
+    #[derive(Clone, Debug)]
+    pub struct GenericsList {
+        inner: Rc<GenericsListInner>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct GenericsListInner {
+        previous: Option<GenericsList>,
+        start_idx: usize,
+        generics_by_id: Vec<u32>,
+    }
+
+    impl GenericsList {
+        /// Return the unique index of a generic in the list, or None if not found
+        pub fn index_for_type_id(&self, type_id: u32) -> Option<usize> {
+            let maybe_index = self
+                .inner
+                .generics_by_id
+                .iter()
+                .enumerate()
+                .find(|(_, id)| **id == type_id)
+                .map(|(index, _)| self.inner.start_idx + index);
+
+            // if index isn't found here, go back to the previous list and try again.
+            maybe_index.or_else(|| {
+                self.inner
+                    .previous
+                    .as_ref()
+                    .and_then(|prev| prev.index_for_type_id(type_id))
+            })
+        }
+
+        /// Create an empty list.
+        pub fn empty() -> Self {
+            Self::new_inner(None, &[])
+        }
+
+        /// Extend this list with more params.
+        pub fn extend(&self, params: &[TypeParameter<PortableForm>]) -> Self {
+            Self::new_inner(Some(self.clone()), params)
+        }
+
+        fn new_inner(
+            maybe_self: Option<GenericsList>,
+            params: &[TypeParameter<PortableForm>],
+        ) -> Self {
+            let generics_by_id = params.iter().filter_map(|p| p.ty.map(|ty| ty.id)).collect();
+
+            let start_idx = match &maybe_self {
+                Some(list) => list.inner.start_idx + list.inner.generics_by_id.len(),
+                None => 0,
+            };
+
+            GenericsList {
+                inner: Rc::new(GenericsListInner {
+                    previous: maybe_self,
+                    start_idx,
+                    generics_by_id,
+                }),
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use scale_info::{meta_type, Path, PortableRegistry};
-
-    use crate::utils::ensure_unique_type_paths;
+    use super::*;
+    use scale_info::{
+        meta_type, Field, Path, PortableRegistry, TypeDef, TypeDefComposite, TypeInfo,
+        TypeParameter,
+    };
 
     #[test]
     fn ensure_unique_type_paths_test() {
@@ -237,5 +378,79 @@ mod tests {
         assert_eq!(ident(id_4), "Foo3");
         assert_eq!(ident(id_5), "Foo3");
         assert_eq!(ident(id_6), "Foo3");
+    }
+
+    #[test]
+    fn types_equal_recursing_test() {
+        #[derive(TypeInfo)]
+        struct Foo<T> {
+            _inner: T,
+        }
+
+        macro_rules! nested_type {
+            ($ty:ident, $generic:ty, $inner:ty) => {
+                struct $ty;
+                impl scale_info::TypeInfo for $ty {
+                    type Identity = Self;
+                    fn type_info() -> scale_info::Type {
+                        scale_info::Type {
+                            path: Path::new("NestedType", "my::module"),
+                            type_params: vec![TypeParameter::new(
+                                "T",
+                                Some(meta_type::<$generic>()),
+                            )],
+                            type_def: TypeDef::Composite(TypeDefComposite::new([Field::new(
+                                None,
+                                meta_type::<$inner>(),
+                                None,
+                                Vec::new(),
+                            )])),
+                            docs: vec![],
+                        }
+                    }
+                }
+            };
+        }
+
+        // A and B are the same because generics explain the param difference.
+        //
+        //NestedType<T = u32>(u32)
+        //NestedType<T = bool>(bool)
+        nested_type!(A, u32, u32);
+        nested_type!(B, bool, bool);
+
+        // As above, but another layer of nesting before generic param used.
+        //
+        //NestedType<T = u32>(Vec<u32>)
+        //NestedType<T = bool>(Vec<bool>)
+        nested_type!(C, bool, Vec<bool>);
+        nested_type!(D, u32, Vec<u32>);
+
+        // A third layer of nesting just to really check the recursion.
+        //
+        //NestedType<T = u32>(Vec<Foo<u32>>)
+        //NestedType<T = bool>(Vec<Foo<bool>>)
+        nested_type!(E, bool, Vec<Foo<bool>>);
+        nested_type!(F, u32, Vec<Foo<u32>>);
+
+        let mut registry = scale_info::Registry::new();
+        let id_a = registry.register_type(&meta_type::<A>()).id;
+        let id_b = registry.register_type(&meta_type::<B>()).id;
+        let id_c = registry.register_type(&meta_type::<C>()).id;
+        let id_d = registry.register_type(&meta_type::<D>()).id;
+        let id_e = registry.register_type(&meta_type::<E>()).id;
+        let id_f = registry.register_type(&meta_type::<F>()).id;
+        let registry = PortableRegistry::from(registry);
+
+        // Despite how many layers of nesting, we identify that the generic
+        // param can explain the difference, so can see them as being equal.
+        assert!(types_equal(id_a, id_b, &registry));
+        assert!(types_equal(id_c, id_d, &registry));
+        assert!(types_equal(id_e, id_f, &registry));
+
+        // Sanity check that the pairs are not equal with eachother.
+        assert!(!types_equal(id_a, id_c, &registry));
+        assert!(!types_equal(id_a, id_e, &registry));
+        assert!(!types_equal(id_c, id_e, &registry));
     }
 }


### PR DESCRIPTION
Recurse through types to check for equality.

The basic algorithm here is:
- If type IDs match, they are the same.
- If type IDs can be explained by the same generic parameter, they are the same.
- If type paths or generic names don't match, they are different.
- If the corresponding TypeDefs (shape of type) is different, they are different.
- Else, recurse through any contained type IDs and start from the top.

Unfortunately, we aren't strictly improving on our type generation from before, ie there are some types that would previously be deduplicated but now arent. Consider these types:

```txt
1: struct Foo<T = u8, U = u8, V = u8>(u8, u8, u8);
2: struct Foo<T = u8, U = u16, V = u32>(u8, u16, u32);
3: struct Foo<T = u8, U = u16, V = u32>(u32, u16, u8);
```

Under the previous approach, we'd gather a set of generics together for each type and see if it could explain both types. However, with this approach, 1 == 2 and 1 == 3 (both could be represented by `Foo<T,U,V>(T,U,V)`) but 2 != 3.
So in extreme cases, it could de-duplicate types that are actually different.

Under the new approach, we map each type to exactly 1 generic param, and fail if they don't both map to the same one. This will miss certain cases, but hopefully also can't incorrectly de-duplicate things. Maybe we can improve this, but I suspect that owuld involve carrying around the actualy generic param mappings with the types so that we can avoid deduplicating where they differ. Needs thought.

### Testing done

- Subxt seems to end up with OK metadata offhand; the new code shaved about 1k lines off a 72k line file (so not too many) and comparing a couple of the differences, everything looked sensible. 
- Specifically, only one BoundedVec and similar now!
- The Subxt tests also passed, and I added a local test, but in the end it's hard to spot edge cases with this stuff!

Closes #19