### PR TITLE
Prep for 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [0.8.0] - 2024-05-24
+
+This release doesn't change the public API, but does effect the generated code to make it more correct and de-duplicate types better, but also a little less forgiving in certain edge cases. As such, I've decided to do a minor bump so that opting in to this change is explicit.
+
+- Improve type equality checking used during de-duplication of types to deduplicate more reliably/often ([#30](https://github.com/paritytech/scale-typegen/pull/30))
+
 # [0.7.0] - 2024-05-15
 
 - Bump `scale-value` to 0.16.0, in order to have only one `scale-decode` in the hierarchy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitvec",
  "frame-metadata 16.0.0",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.7.0"
+version = "0.8.0"
 rust-version = "1.70.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
 homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
-scale-typegen-description = { version = "0.7.0", path = "description" }
-scale-typegen = { version = "0.7.0", path = "typegen" }
+scale-typegen-description = { version = "0.8.0", path = "description" }
+scale-typegen = { version = "0.8.0", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.5", features = ["derive"] }


### PR DESCRIPTION
# [0.8.0] - 2024-05-24

This release doesn't change the public API, but does effect the generated code to make it more correct and de-duplicate types better, but also a little less forgiving in certain edge cases. As such, I've decided to do a minor bump so that opting in to this change is explicit.

- Improve type equality checking used during de-duplication of types to deduplicate more reliably/often ([#30](https://github.com/paritytech/scale-typegen/pull/30))