### PR TITLE
Unify more generic types

### DIFF
--- a/typegen/src/tests/mod.rs
+++ b/typegen/src/tests/mod.rs
@@ -33,58 +33,100 @@ mod utils;
 // // 1 == 2 and 1 == 3 (both could be represented by `Foo<T,U,V>(T,U,V)`) but 2 != 3.
 // // needs more thought.
 // //
-// #[test]
-// fn more_than_1_generic_parameters() {
-//     #[allow(unused)]
-//     #[derive(TypeInfo)]
-//     struct Foo<T, U, V, W> {
-//         a: T,
-//         b: U,
-//         c: V,
-//         d: W,
-//     }
-//
-//     #[allow(unused)]
-//     #[derive(TypeInfo)]
-//     struct Bar {
-//         p: Foo<u32, u32, u64, u128>,
-//         q: Foo<u8, u8, u8, u8>,
-//     }
-//
-//     let generated = Testgen::new()
-//         .with::<Bar>()
-//         .gen_tests_mod(Default::default());
-//
-//     #[rustfmt::skip]
-//     let expected = quote!(
-//         pub mod tests {
-//             use super::types;
-//             pub struct Bar {
-//                 pub p: types::scale_typegen::tests::Foo<
-//                     ::core::primitive::u32,
-//                     ::core::primitive::u32,
-//                     ::core::primitive::u64,
-//                     ::core::primitive::u128
-//                 >,
-//                 pub q: types::scale_typegen::tests::Foo<
-//                     ::core::primitive::u8,
-//                     ::core::primitive::u8,
-//                     ::core::primitive::u8,
-//                     ::core::primitive::u8
-//                 >,
-//             }
-//             pub struct Foo<_0, _1, _2, _3> {
-//                 pub a: _0,
-//                 pub b: _1,
-//                 pub c: _2,
-//                 pub d: _3,
-//             }
-//         }
-//     );
-//
-//     assert_eq!(generated.to_string(), expected.to_string());
-// }
 
+#[test]
+fn more_than_1_generic_parameters() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Foo<T, U, V, W> {
+        a: T,
+        b: U,
+        c: V,
+        d: W,
+    }
+
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Bar {
+        p: Foo<u32, u32, u64, u128>,
+        q: Foo<u8, u8, u8, u8>,
+    }
+
+    let generated = Testgen::new()
+        .with::<Bar>()
+        .gen_tests_mod(Default::default());
+
+    #[rustfmt::skip]
+    let expected = quote!(
+        pub mod tests {
+            use super::types;
+            pub struct Bar {
+                pub p: types::scale_typegen::tests::Foo<
+                    ::core::primitive::u32,
+                    ::core::primitive::u32,
+                    ::core::primitive::u64,
+                    ::core::primitive::u128
+                >,
+                pub q: types::scale_typegen::tests::Foo<
+                    ::core::primitive::u8,
+                    ::core::primitive::u8,
+                    ::core::primitive::u8,
+                    ::core::primitive::u8
+                >,
+            }
+            pub struct Foo<_0, _1, _2, _3> {
+                pub a: _0,
+                pub b: _1,
+                pub c: _2,
+                pub d: _3,
+            }
+        }
+    );
+
+    assert_eq!(generated.to_string(), expected.to_string());
+}
+
+#[test]
+fn more_than_1_generic_parameters_tuple() {
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Foo<T, U, V, W>(T, U, V, W);
+
+    #[allow(unused)]
+    #[derive(TypeInfo)]
+    struct Bar {
+        p: Foo<u32, u32, u64, u128>,
+        q: Foo<u8, u8, u8, u8>,
+    }
+
+    let generated = Testgen::new()
+        .with::<Bar>()
+        .gen_tests_mod(Default::default());
+
+    #[rustfmt::skip]
+    let expected = quote!(
+        pub mod tests {
+            use super::types;
+            pub struct Bar {
+                pub p: types::scale_typegen::tests::Foo<
+                    ::core::primitive::u32,
+                    ::core::primitive::u32,
+                    ::core::primitive::u64,
+                    ::core::primitive::u128
+                >,
+                pub q: types::scale_typegen::tests::Foo<
+                    ::core::primitive::u8,
+                    ::core::primitive::u8,
+                    ::core::primitive::u8,
+                    ::core::primitive::u8
+                >,
+            }
+            pub struct Foo<_0, _1, _2, _3>(pub _0, pub _1, pub _2, pub _3 ,);
+        }
+    );
+
+    assert_eq!(generated.to_string(), expected.to_string());
+}
 #[test]
 fn dupe_types_do_not_overwrite_each_other() {
     enum Foo {}

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -146,6 +146,7 @@ fn types_equal_inner(
         let b_params = b_parent_params.extend(&b_ty.type_params);
         (a_params, b_params)
     };
+
     // If both IDs map to same generic param, then we'll assume equal. If they don't
     // then we need to keep checking other properties (eg Vec<bool> and Vec<u8> will have
     // different type IDs but may be the same type if the bool+u8 line up to generic params).

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -170,7 +170,10 @@ fn types_equal_inner(
             param.type_name.as_ref().is_some_and(|x| x.contains("::"))
         }
 
-        let equal_name = a.name == b.name;
+        if a.name != b.name {
+            return false;
+        }
+
         let ty_indexes_deleted = a_params
             .index_for_type_id(a.ty.id)
             .zip(b_params.index_for_type_id(b.ty.id))

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -172,7 +172,8 @@ fn types_equal_inner(
             return false;
         }
 
-        // Vec<T>, Option<T>, etc and #[scale_info(skip_type_params(T))]
+        // The type is wrapped in another type such as `Vec<T>` or 
+        // marked as skipped with `#[scale_info(skip_type_params(T))]`
         let ty_is_skipped_or_wrapped = a_params
             .index_for_type_id(a.ty.id)
             .zip(b_params.index_for_type_id(b.ty.id))

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -307,7 +307,7 @@ mod generics_list {
                     .and_then(|prev| prev.index_for_type_id(type_id))
             })
         }
-        /// Return the unique index of a generic in the list, or None if not found
+        /// Returns the unique index of a generic type name, or None if not found.
         pub fn index_for_type_name(&self, name: &str) -> Option<usize> {
             let maybe_index = self
                 .inner


### PR DESCRIPTION
### Description 
this is an attempt to unify more generic types, so instead of having multiple instances of the same type we would have one generic instance. 
Here we also introduce structural checking for fields of generic structs and enums.

i've added more tests for examples

### Examples
```rust
// we won't care about the fact that generic param names are different now
// so example below will get deduplicated.
struct Foo<A = u8>(A) == struct Foo<B = u32>(B) 

// struct below will not get deduplicated as field ordering is different
struct Foo<A,B>(A,B) != struct Foo<A,B>(B,A)

// struct Foo will get reused for both usages below
struct Foo<T>(T)

struct Bar {
  a: Foo<u8>, 
  b: Foo<u32>,
}
```

Also tested the same equivalences for nested and recursive types.

### Weirdness around Box'es: 
we can generate bogus code for recursive types without defining the shared base type first and we use Box as our container, everything will work as expected for Vecs
eg: 
```rust
       #[derive(TypeInfo)]
        #[allow(dead_code)]
        pub struct TestStruct<A> {
            param: A,
            inner: Vec<Self>,
        }

        #[derive(TypeInfo)]
        #[allow(dead_code)]
        pub struct Foo<T> {
            inner: Box<T>,
        }
        ...
        // let id_foo = registry.register_type(&meta_type::<Foo<u32>>()).id; this will only generate case for u32
        let id_foo_foo = registry
            .register_type(&meta_type::<Foo<Foo<TestStruct<u32>>>>())
            .id;
        // id_foo_foo will produce: 
        // pub struct Foo<_0> {
        //     pub inner: ::std::boxed::Box<
        //         types::scale_typegen::utils::tests::Foo<
        //             types::scale_typegen::utils::tests::TestStruct<::core::primitive::u32>,
        //         >,
        //     >,
        //     pub __ignore: ::core::marker::PhantomData<_0>,
        // }
```

Edit: Box is not supported in scale-info(?)