### PR TITLE
Shorter type names in recursive types

### DIFF
--- a/typegen/src/tests/utils.rs
+++ b/typegen/src/tests/utils.rs
@@ -78,6 +78,7 @@ pub(super) fn subxt_settings() -> TypeGeneratorSettings {
         compact_as_type_path: Some(parse_quote!(::subxt_path::ext::codec::CompactAs)),
         compact_type_path: Some(parse_quote!(::subxt_path::ext::codec::Compact)),
         alloc_crate_path: Default::default(),
+        parent_path: std::cell::RefCell::default(),
     }
 }
 /// Derives mirroring the subxt default derives

--- a/typegen/src/typegen/ir/module_ir.rs
+++ b/typegen/src/typegen/ir/module_ir.rs
@@ -51,9 +51,7 @@ impl ToTokensWithSettings for ModuleIR {
                     path.segments = punctuated;
                     path
                 });
-                let res =
-                    settings.with_parent_path(parent_path, |settings| ir.to_token_stream(settings));
-                res
+                settings.with_parent_path(parent_path, |settings| ir.to_token_stream(settings))
             })
             .clone();
 

--- a/typegen/src/typegen/ir/type_ir.rs
+++ b/typegen/src/typegen/ir/type_ir.rs
@@ -294,7 +294,7 @@ impl CompositeIR {
 
 impl ToTokensWithSettings for CompositeFieldIR {
     fn to_tokens(&self, tokens: &mut TokenStream, settings: &TypeGeneratorSettings) {
-        let ty_path = &self.type_path.to_syn_type(&settings.alloc_crate_path);
+        let ty_path = &self.type_path.to_syn_type(&settings);
         if self.is_boxed {
             let alloc_path = &settings.alloc_crate_path;
             tokens.extend(quote! { #alloc_path::boxed::Box<#ty_path> })

--- a/typegen/src/typegen/ir/type_ir.rs
+++ b/typegen/src/typegen/ir/type_ir.rs
@@ -294,7 +294,7 @@ impl CompositeIR {
 
 impl ToTokensWithSettings for CompositeFieldIR {
     fn to_tokens(&self, tokens: &mut TokenStream, settings: &TypeGeneratorSettings) {
-        let ty_path = &self.type_path.to_syn_type(&settings);
+        let ty_path = &self.type_path.to_syn_type(settings);
         if self.is_boxed {
             let alloc_path = &settings.alloc_crate_path;
             tokens.extend(quote! { #alloc_path::boxed::Box<#ty_path> })

--- a/typegen/src/typegen/settings/mod.rs
+++ b/typegen/src/typegen/settings/mod.rs
@@ -99,7 +99,7 @@ impl TypeGeneratorSettings {
         T: FnOnce(&Self) -> proc_macro2::TokenStream,
     {
         let old_path = self.parent_path.replace(path);
-        let result = f(&self);
+        let result = f(self);
         self.parent_path.replace(old_path);
         result
     }

--- a/typegen/src/typegen/settings/substitutes.rs
+++ b/typegen/src/typegen/settings/substitutes.rs
@@ -295,7 +295,7 @@ fn replace_path_params_recursively<I: Borrow<syn::Ident>, P: Borrow<TypePath>>(
             };
             if let Some(ident) = get_ident_from_type_path(path) {
                 if let Some((_, replacement)) = params.iter().find(|(i, _)| ident == i.borrow()) {
-                    *ty = replacement.borrow().to_syn_type(&settings.alloc_crate_path);
+                    *ty = replacement.borrow().to_syn_type(&settings);
                     continue;
                 }
             }

--- a/typegen/src/typegen/settings/substitutes.rs
+++ b/typegen/src/typegen/settings/substitutes.rs
@@ -295,7 +295,7 @@ fn replace_path_params_recursively<I: Borrow<syn::Ident>, P: Borrow<TypePath>>(
             };
             if let Some(ident) = get_ident_from_type_path(path) {
                 if let Some((_, replacement)) = params.iter().find(|(i, _)| ident == i.borrow()) {
-                    *ty = replacement.borrow().to_syn_type(&settings);
+                    *ty = replacement.borrow().to_syn_type(settings);
                     continue;
                 }
             }

--- a/typegen/src/typegen/type_path.rs
+++ b/typegen/src/typegen/type_path.rs
@@ -30,7 +30,7 @@ pub enum TypePathInner {
 
 impl ToTokensWithSettings for TypePath {
     fn to_tokens(&self, tokens: &mut TokenStream, settings: &TypeGeneratorSettings) {
-        let syn_type = self.to_syn_type(&settings);
+        let syn_type = self.to_syn_type(settings);
         syn_type.to_tokens(tokens)
     }
 }


### PR DESCRIPTION
### Description: 
This is a workaround for trait bounds generated for recursive types in scale-codec.(see paritytech/parity-scale-codec#603, fixes paritytech/subxt#1603). 
To generate short `Path`s in recursive types we will be temporarily storing `parent_path` inside the settings struct that's passed around when generating `TokenStream`s.
So instead of passing just the `alloc_crate_path` to the `TypePath::to_syn_type` we will pass all of the `settings` to make use of `parent_path`.  So when we encounter a `Path` with a param and it will be equal to the `parent_path` we will only leave the last segment inside of it.

### Examples: 
```rust
  #[allow(unused)]
    #[derive(TypeInfo)]
    #[scale_info(skip_type_params(A))]
    struct Example<A, B> {
        id: A,
        rest: B,
        inner: Vec<Example<A, B>>,
    }
    ...
    // Registered:  
    let for_codegen = Testgen::new()
        .with::<Example<String, u32>>()
        .with::<Example<u8, u32>>()
        .with::<Example<u16, u32>>()
        .try_gen_tests_mod(Default::default(), true)
        .unwrap();
    ... 
    /// Generated 
        let expected = quote! {
        pub mod tests {
            use super::types;
            pub struct Example1<_1> {
                pub id: ::std::string::String,
                pub rest: _1,
                // Note the short path for `Example<_>`
                pub inner: ::std::vec::Vec<Example1<_1> >,
            }
            pub struct Example2<_1> {
                pub id: ::core::primitive::u8,
                pub rest: _1,
                pub inner: ::std::vec::Vec<Example2<_1> >,
            }
            pub struct Example3<_1> {
                pub id: ::core::primitive::u16,
                pub rest: _1,
                pub inner: ::std::vec::Vec<Example3<_1> >,
            }
        }
    };
```
