### PR TITLE
Return error on incorrect PortableRegistry

### DIFF
--- a/typegen/src/tests/mod.rs
+++ b/typegen/src/tests/mod.rs
@@ -1518,7 +1518,7 @@ fn ensure_unique_type_paths_test() {
         ]
     );
 
-    ensure_unique_type_paths(&mut registry);
+    ensure_unique_type_paths(&mut registry).expect("Corrupted PortableRegistry");
 
     let e2 = sorted_type_paths(&registry);
     assert_eq!(
@@ -1661,6 +1661,7 @@ fn assoc_types_skip_params() {
     #[derive(TypeInfo)]
     #[scale_info(skip_type_params(T))]
     pub struct X<T: Config> {
+        #[allow(dead_code)]
         pub inner: T::Inner,
     }
 
@@ -1715,6 +1716,7 @@ fn assoc_types_no_skip_params() {
 
     #[derive(TypeInfo)]
     pub struct X<T: Config> {
+        #[allow(dead_code)]
         pub inner: T::Inner,
     }
 

--- a/typegen/src/tests/utils.rs
+++ b/typegen/src/tests/utils.rs
@@ -37,7 +37,7 @@ impl Testgen {
 
     pub fn gen(self, settings: TypeGeneratorSettings) -> TokenStream {
         let mut registry: PortableRegistry = self.registry.into();
-        ensure_unique_type_paths(&mut registry).expect("corrupted PortableRegistry");
+        ensure_unique_type_paths(&mut registry).expect("Corrupted PortableRegistry");
         let type_gen = TypeGenerator::new(&registry, &settings);
         let module = type_gen.generate_types_mod().unwrap();
         module.to_token_stream(&settings)
@@ -50,7 +50,7 @@ impl Testgen {
     ) -> Result<TokenStream, TypegenError> {
         let mut registry: PortableRegistry = self.registry.into();
         if deduplicate {
-            ensure_unique_type_paths(&mut registry).expect("corrupted PortableRegistry")
+            ensure_unique_type_paths(&mut registry).expect("Corrupted PortableRegistry")
         }
         let type_gen = TypeGenerator::new(&registry, &settings);
         type_gen.generate_types_mod().map(|module| {

--- a/typegen/src/tests/utils.rs
+++ b/typegen/src/tests/utils.rs
@@ -37,7 +37,7 @@ impl Testgen {
 
     pub fn gen(self, settings: TypeGeneratorSettings) -> TokenStream {
         let mut registry: PortableRegistry = self.registry.into();
-        ensure_unique_type_paths(&mut registry);
+        ensure_unique_type_paths(&mut registry).expect("corrupted PortableRegistry");
         let type_gen = TypeGenerator::new(&registry, &settings);
         let module = type_gen.generate_types_mod().unwrap();
         module.to_token_stream(&settings)
@@ -50,7 +50,7 @@ impl Testgen {
     ) -> Result<TokenStream, TypegenError> {
         let mut registry: PortableRegistry = self.registry.into();
         if deduplicate {
-            ensure_unique_type_paths(&mut registry)
+            ensure_unique_type_paths(&mut registry).expect("corrupted PortableRegistry")
         }
         let type_gen = TypeGenerator::new(&registry, &settings);
         type_gen.generate_types_mod().map(|module| {

--- a/typegen/src/typegen/error.rs
+++ b/typegen/src/typegen/error.rs
@@ -36,14 +36,14 @@ pub enum TypegenError {
     #[error("There are two types with the the same type path {0} but different structure. Use `scale_typegen::utils::ensure_unique_type_paths` on your `PortableRegistry` before, to avoid this error.")]
     DuplicateTypePath(String),
     /// PortableRegistry entry has incorrect Id.
-    #[error("PortableRegistry entry has incorrect type_id. expected type_id: {expected_ty_id}, got: {given_ty_id}.\nPath of the type: {ty_path:?}.\n This can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata for use with `TypeGenerator`.")]
+    #[error("PortableRegistry entry has incorrect type_id. expected type_id: {expected_ty_id}, got: {given_ty_id}.\nDefinition of the type: {ty_def}.\nThis can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata for use with `TypeGenerator`.")]
     RegistryIncorrect {
         /// Received type id
         given_ty_id: u32,
         /// Expected type id
         expected_ty_id: u32,
         /// Type definition
-        ty_path: String,
+        ty_def: String,
     },
 }
 

--- a/typegen/src/typegen/error.rs
+++ b/typegen/src/typegen/error.rs
@@ -36,7 +36,7 @@ pub enum TypegenError {
     #[error("There are two types with the the same type path {0} but different structure. Use `scale_typegen::utils::ensure_unique_type_paths` on your `PortableRegistry` before, to avoid this error.")]
     DuplicateTypePath(String),
     /// PortableRegistry entry has incorrect Id.
-    #[error("PortableRegistry entry has incorrect type_id. expected type_id: {expected_ty_id}, got: {given_ty_id}.\nDefinition of the type: {ty_def}.\nThis can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata for use with `TypeGenerator`.")]
+    #[error("PortableRegistry entry has incorrect type_id. expected type_id: {expected_ty_id}, got: {given_ty_id}.\nDefinition of the type: {ty_def}.\nThis can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata to fix this.")]
     RegistryIncorrect {
         /// Received type id
         given_ty_id: u32,

--- a/typegen/src/typegen/error.rs
+++ b/typegen/src/typegen/error.rs
@@ -35,6 +35,16 @@ pub enum TypegenError {
     /// Use [`crate::utils::ensure_unique_type_paths`] on your [`scale_info::PortableRegistry`] to deduplicate type paths.
     #[error("There are two types with the the same type path {0} but different structure. Use `scale_typegen::utils::ensure_unique_type_paths` on your `PortableRegistry` before, to avoid this error.")]
     DuplicateTypePath(String),
+    /// PortableRegistry entry has incorrect Id.
+    #[error("PortableRegistry entry has incorrect type_id. expected type_id: {expected_ty_id}, got: {given_ty_id}.\nPath of the type: {ty_path:?}.\n This can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata for use with `TypeGenerator`.")]
+    RegistryIncorrect {
+        /// Received type id
+        given_ty_id: u32,
+        /// Expected type id
+        expected_ty_id: u32,
+        /// Type definition
+        ty_path: String,
+    },
 }
 
 /// Error attempting to do type substitution.

--- a/typegen/src/typegen/error.rs
+++ b/typegen/src/typegen/error.rs
@@ -37,7 +37,7 @@ pub enum TypegenError {
     DuplicateTypePath(String),
     /// PortableRegistry entry has incorrect Id.
     #[error("PortableRegistry entry has incorrect type_id. expected type_id: {expected_ty_id}, got: {given_ty_id}.\nDefinition of the type: {ty_def}.\nThis can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata to fix this.")]
-    RegistryIncorrect {
+    RegistryTypeIdsInvalid {
         /// Received type id
         given_ty_id: u32,
         /// Expected type id

--- a/typegen/src/typegen/mod.rs
+++ b/typegen/src/typegen/mod.rs
@@ -1,6 +1,9 @@
 use std::collections::btree_map::Entry;
 
-use crate::{utils::types_equal, TypegenError};
+use crate::{
+    utils::{sanity_pass, types_equal},
+    TypegenError,
+};
 
 use self::{
     ir::module_ir::ModuleIR,
@@ -65,6 +68,8 @@ impl<'a> TypeGenerator<'a> {
 
     /// Generate a module containing all types defined in the supplied type registry.
     pub fn generate_types_mod(&self) -> Result<ModuleIR, TypegenError> {
+        sanity_pass(self.type_registry)?;
+
         let flat_derives_registry = self
             .settings
             .derives

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -15,7 +15,7 @@ pub(crate) fn sanity_pass(types: &PortableRegistry) -> Result<(), TypegenError> 
     for (idx, ty) in types.types.iter().enumerate() {
         let idx = idx as u32;
         if ty.id != idx {
-            return Err(TypegenError::RegistryIncorrect {
+            return Err(TypegenError::RegistryTypeIdsInvalid {
                 given_ty_id: ty.id,
                 expected_ty_id: idx,
                 ty_def: format!("{:#?}", ty.ty),

--- a/typegen/src/utils.rs
+++ b/typegen/src/utils.rs
@@ -18,7 +18,7 @@ pub(crate) fn sanity_pass(types: &PortableRegistry) -> Result<(), TypegenError> 
             return Err(TypegenError::RegistryIncorrect {
                 given_ty_id: ty.id,
                 expected_ty_id: idx,
-                ty_path: ty.ty.path.to_string(),
+                ty_def: format!("{:#?}", ty.ty),
             });
         }
     }


### PR DESCRIPTION
### Description 
With this MR we will return an error if `ty.id` do not correspond to the `index` of the type inside PortableRegistry. 

see paritytech/subxt#1648

Example error produced with this MR: 
```rust
error: Type Generation failed: PortableRegistry entry has incorrect type_id. expected type_id: 0, got: 2.
       Definition of the type: Type {
           path: Path {
               segments: [],
           },
           type_params: [],
           type_def: Primitive(
               U8,
           ),
           docs: [],
       }.
       This can happen if registry was modified with calls to `::retain()` in older versions of scale-info. Try generating a new metadata for use with `TypeGenerator`.
 --> subxt/examples/events.rs:3:1
  |
3 | #[subxt::subxt(runtime_metadata_path = "../rococo-bajun.scale")]
```
### Alternative 
- Traverse PortableRegistry ourselves and fixup type_ids manually before operating on types inside that Registry.