### PR TITLE
Prep to release 0.11.1 with Duration added to prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.11.1] - 2025-05-07
+
+- Add `core::time::Duration` to the list of prelude types.
+
 # [0.11.0] - 2025-03-05
 
 - Bump `frame-metadata` to latest (20.0.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bitvec",
  "frame-metadata",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen-description"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ resolver = "2"
 [workspace.package]
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
-version = "0.11.0"
+version = "0.11.1"
 rust-version = "1.81.0"
 license = "Apache-2.0 OR GPL-3.0"
 repository = "https://github.com/paritytech/scale-typegen"
 homepage = "https://www.parity.io/"
 
 [workspace.dependencies]
-scale-typegen-description = { version = "0.11.0", path = "description" }
-scale-typegen = { version = "0.11.0", path = "typegen" }
+scale-typegen-description = { version = "0.11.1", path = "description" }
+scale-typegen = { version = "0.11.1", path = "typegen" }
 
 # external dependencies
 parity-scale-codec = { version = "3.6.12", features = ["derive"] }

--- a/typegen/src/typegen/type_path.rs
+++ b/typegen/src/typegen/type_path.rs
@@ -216,6 +216,7 @@ impl TypePathType {
                     "NonZeroU128" => parse_quote!(::core::num::NonZeroU128),
                     "NonZeroIsize" => parse_quote!(::core::num::NonZeroIsize),
                     "NonZeroUsize" => parse_quote!(::core::num::NonZeroUsize),
+                    "Duration" => parse_quote!(::core::time::Duration),
                     ident => panic!("Unknown prelude type '{ident}'"),
                 }
             }


### PR DESCRIPTION
This fixes an issue in Subxt which likely relates to Duration being made use of in a runtime now.